### PR TITLE
Small fixes / improvements:

### DIFF
--- a/source/ca.backup2/usr/local/emhttp/plugins/ca.backup2/Backup.page
+++ b/source/ca.backup2/usr/local/emhttp/plugins/ca.backup2/Backup.page
@@ -180,10 +180,7 @@ for ( $minute = 0; $minute < 60; $minute++ ) {
 }
 
 for ( $hour = 0; $hour < 24; $hour++ ) {
-  if ( $hour > 11 ) { $suffix = "PM"; $easyHour = $hour - 12; } else { $suffix = "AM"; $easyHour = $hour; }
-  if ( $easyHour == 0 ) { $easyHour = 12; }
-
-  $cronHour .= "<option value='$hour'>$easyHour$suffix</option>";
+  $cronHour .= "<option value='$hour'>$hour</option>";
 }
 
 if ( $dockerRunning == "true" ) {

--- a/source/ca.backup2/usr/local/emhttp/plugins/ca.backup2/Backup.page
+++ b/source/ca.backup2/usr/local/emhttp/plugins/ca.backup2/Backup.page
@@ -71,6 +71,7 @@ if ( ! isset($backupOptions['dockerStopDelay']) ) { $backupOptions['dockerStopDe
 if ( ! isset($backupOptions['compression']) ) { $backupOptions['compression'] = 'no'; }
 if ( ! isset($backupOptions['verify']) ) { $backupOptions['verify'] = "yes"; }
 if ( ! isset($backupOptions['hideDockerWarning']) ) { $backupOptions['hideDockerWarning'] = "no"; }
+if ( ! isset($backupOptions['separateArchives']) ) { $backupOptions['separateArchives'] = "no"; }
 
 # fix destinationShare for compatibility with initial release
 
@@ -270,7 +271,8 @@ $(function() {
 	$("#compression").val("<?=$backupOptions['compression']?>");
 	$("#verify").val("<?=$backupOptions['verify']?>");
 	$("#hideDockerWarning").val("<?=$backupOptions['hideDockerWarning']?>");
-  
+	$("#separateArchives").val("<?=$backupOptions['separateArchives']?>");
+
   if ( "<?=$caUpdateInstalled?>" != "true" ) {
     $("#updateApps").prop("disabled",true);
   }
@@ -566,6 +568,14 @@ function toggleDockerStop(el) {
 <tr>
 	<td><b>Verify Backups?</b></td>
 	<td><select class='setting' id='verify' onchange='validateOptions();'>
+		<option value='no'>No</option>
+		<option value='yes'>Yes</option>
+	</select>
+	</td>
+</tr>
+<tr>
+	<td><b>Create separate archives (one per folder)?</b></td>
+	<td><select class='setting' id='separateArchives' onchange='validateOptions();'>
 		<option value='no'>No</option>
 		<option value='yes'>Yes</option>
 	</select>

--- a/source/ca.backup2/usr/local/emhttp/plugins/ca.backup2/Backup.page
+++ b/source/ca.backup2/usr/local/emhttp/plugins/ca.backup2/Backup.page
@@ -70,6 +70,7 @@ if ( ! isset($backupOptions['updateApps']) ) { $backupOptions['updateApps'] = "n
 if ( ! isset($backupOptions['dockerStopDelay']) ) { $backupOptions['dockerStopDelay'] = 60; }
 if ( ! isset($backupOptions['compression']) ) { $backupOptions['compression'] = 'no'; }
 if ( ! isset($backupOptions['verify']) ) { $backupOptions['verify'] = "yes"; }
+if ( ! isset($backupOptions['hideDockerWarning']) ) { $backupOptions['hideDockerWarning'] = "no"; }
 
 # fix destinationShare for compatibility with initial release
 
@@ -238,8 +239,11 @@ $(function() {
   <?if (! $tabbed):?>
   $(".tabbedOnly").hide();
   <?endif;?>
+
+  <?php if($backupOptions['hideDockerWarning'] == 'no'):?>
   myAlert("Appdata Backup","When a Backup is running (<em>either manually or a scheduled backup</em>), your docker applications will be <b><font color='red'>stopped</font></b> and then <b><font color='red'>restarted</font></b> at the conclusion of the backup","","",false,"",true,"warning");
-  
+  <?php endif; ?>
+
   $("#source").val("<?=$backupOptions['source']?>");
   $("#fasterRsync").val("<?=$backupOptions['fasterRsync']?>");
   $("#deleteOldBackup").val("<?=$backupOptions['deleteOldBackup']?>");
@@ -265,6 +269,7 @@ $(function() {
   $("#dockerStopDelay").val("<?=$backupOptions['dockerStopDelay']?>");
 	$("#compression").val("<?=$backupOptions['compression']?>");
 	$("#verify").val("<?=$backupOptions['verify']?>");
+	$("#hideDockerWarning").val("<?=$backupOptions['hideDockerWarning']?>");
   
   if ( "<?=$caUpdateInstalled?>" != "true" ) {
     $("#updateApps").prop("disabled",true);
@@ -693,6 +698,16 @@ function toggleDockerStop(el) {
 <center><a onclick='showAdvanced();' style='cursor:pointer'><span id='showAdvanced' class='advancedHidden'>Show Advanced Settings</span></a></center>
 <br>
 <span id='advancedSettings' style='display:none'>
+<br>
+<table>
+    <tr>
+        <td><b>Hide the docker warning message when opening CA.Backup settings</b></td>
+        <td><select class='setting' id='hideDockerWarning' onchange='validateOptions();'>
+            		<option value='no'>No</option>
+            		<option value='yes'>Yes</option>
+            		</select></td>
+    </tr>
+</table>
 <br>
 <font size='2'><b>Select which applications to NOT stop during a backup</b></font><br>
 Note that it is recommended to also exclude from the backup any associated appdata shares from the backup set to ensure that the backup / restore will not fail due to open files, etc</font><br>

--- a/source/ca.backup2/usr/local/emhttp/plugins/ca.backup2/Status.page
+++ b/source/ca.backup2/usr/local/emhttp/plugins/ca.backup2/Status.page
@@ -24,8 +24,7 @@ function checkBackup() {
 > <center><a href='https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=7M7CBCVU732XG' target='_blank'><img src="https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif"></a></center>
 
 <font size='2'>Backup / Restore Status: <span id='backupStatus'></span></font>
-<div style='border:1px;border-style:solid;border-color:red;height:300px;overflow:auto' id='backupLines' >
-<span id='backupLinesas'><br><br><br></span></div>
+<div style='border:1px;border-style:solid;border-color:red;height:300px;overflow:auto' id='backupLines' ></div>
 
 <input type='button' value='Abort' id='abort' onclick='abort();' disabled>
 

--- a/source/ca.backup2/usr/local/emhttp/plugins/ca.backup2/Status.page
+++ b/source/ca.backup2/usr/local/emhttp/plugins/ca.backup2/Status.page
@@ -23,9 +23,9 @@ function checkBackup() {
 > <center>For support for this plugin, visit here: <a href="https://forums.lime-technology.com/topic/61211-plugin-ca-appdata-backup-restore-v2/" target="_blank">HERE</a></center>
 > <center><a href='https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=7M7CBCVU732XG' target='_blank'><img src="https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif"></a></center>
 
-<div style='border:1px;border-style:solid;border-color:red;height:200px;overflow:hidden' ><font size='2'>Backup / Restore Status: <span id='backupStatus'></span>
-<br>
-<span id='backupLines'><br><br><br></span></div>
+<font size='2'>Backup / Restore Status: <span id='backupStatus'></span></font>
+<div style='border:1px;border-style:solid;border-color:red;height:300px;overflow:auto' id='backupLines' >
+<span id='backupLinesas'><br><br><br></span></div>
 
 <input type='button' value='Abort' id='abort' onclick='abort();' disabled>
 

--- a/source/ca.backup2/usr/local/emhttp/plugins/ca.backup2/include/backupExec.php
+++ b/source/ca.backup2/usr/local/emhttp/plugins/ca.backup2/include/backupExec.php
@@ -18,7 +18,7 @@ function getDates() {
     return "No Backup Sets Found";
   }
   foreach ($availableDates as $date) {
-		if ( is_file("{$backupOptions['destinationShare']}/$date/CA_backup.tar") || is_file("{$backupOptions['destinationShare']}/$date/CA_backup.tar.gz") ) {
+		if (strpos($date, 'error') === false ) {
 			$output .= '<option value="'.$date.'">'.$date.'</option>';
 		}
   }

--- a/source/ca.backup2/usr/local/emhttp/plugins/ca.backup2/scripts/backup.php
+++ b/source/ca.backup2/usr/local/emhttp/plugins/ca.backup2/scripts/backup.php
@@ -107,6 +107,8 @@ logger('#######################################');
 if ( $backupOptions['notification'] == "always" ) {
 	notify("Community Applications","appData $restoreMsg","$restoreMsg of appData starting.  This may take awhile");
 }
+
+backupLog("$restoreMsg of appData starting. This may take awhile");
 	
 if ( $backupOptions['stopScript'] ) {
 	logger("executing custom stop script ".$backupOptions['stopScript']);  backupLog("Executing custom stop script");
@@ -202,7 +204,7 @@ if ( ! $restore )
 
 logger("$restoreMsg Complete");
 if ( $backupOptions['verify'] == "yes" && ! $restore) {
-	$command = "cd ".escapeshellarg("$source")." && /usr/bin/tar --diff -C '$source' -af ".escapeshellarg("$destination/CA_backup$fileExt")." >> {$communityPaths['backupLog']} & echo $! > {$communityPaths['verifyProgress']}";
+	$command = "cd ".escapeshellarg("$source")." && /usr/bin/tar --diff -C '$source' -af ".escapeshellarg("$destination/CA_backup$fileExt")." >> {$communityPaths['backupLog']} 2>&1 & echo $! > {$communityPaths['verifyProgress']}";
 	logger("Verifying backup"); backupLog("Verifying Backup");
 	logger("Using command: $command"); backupLog("Using command: $command");
 	exec($command,$out,$returnValue);

--- a/source/ca.backup2/usr/local/emhttp/plugins/ca.backup2/scripts/backup.php
+++ b/source/ca.backup2/usr/local/emhttp/plugins/ca.backup2/scripts/backup.php
@@ -4,7 +4,7 @@
 #                                                             #
 # Community Applications copyright 2015-2020, Andrew Zawadzki #
 #                                                             #
-############################################################### 
+###############################################################
 
 if ( $argv[1] == "restore" ) {
 	$restore = true;
@@ -18,13 +18,20 @@ require_once("/usr/local/emhttp/plugins/dynamix.docker.manager/include/DockerCli
 require_once("/usr/local/emhttp/plugins/ca.backup2/include/paths.php");
 require_once("/usr/local/emhttp/plugins/ca.backup2/include/helpers.php");
 
+/** @var $communityPaths array */
+
 exec("rm -rf ".$communityPaths['backupLog']);
 exec("mkdir -p /var/lib/docker/unraid/ca.backup2.datastore");
 
+/**
+ * Logs a message to the Backup Log (the one shown at "Backup / Restore status"
+ * @param $msg string The Text to be logged
+ * @return void
+ */
 function backupLog($msg) {
 	global $communityPaths;
 	
-	file_put_contents($communityPaths['backupLog'],"$msg\n",FILE_APPEND);
+	file_put_contents($communityPaths['backupLog'],"[".date("d.m.Y H:i:s")."] $msg\n",FILE_APPEND);
 }
 
 if ( ! is_dir("/mnt/user") ) {
@@ -62,7 +69,7 @@ if ( $restore ) {
 		exit;
 	}
 }
-@unlink($communityPaths['backupLog']);
+
 $dockerSettings = @my_parse_ini_file($communityPaths['unRaidDockerSettings']);
 
 if ( $restore ) {
@@ -195,7 +202,7 @@ if ( ! $restore )
 
 logger("$restoreMsg Complete");
 if ( $backupOptions['verify'] == "yes" && ! $restore) {
-	$command = "cd ".escapeshellarg("$source")." && /usr/bin/tar --diff -C '$source' -af ".escapeshellarg("$destination/CA_backup$fileExt")." > {$communityPaths['backupLog']} & echo $! > {$communityPaths['verifyProgress']}";
+	$command = "cd ".escapeshellarg("$source")." && /usr/bin/tar --diff -C '$source' -af ".escapeshellarg("$destination/CA_backup$fileExt")." >> {$communityPaths['backupLog']} & echo $! > {$communityPaths['verifyProgress']}";
 	logger("Verifying backup"); backupLog("Verifying Backup");
 	logger("Using command: $command"); backupLog("Using command: $command");
 	exec($command,$out,$returnValue);


### PR DESCRIPTION
* Include Date & Time for `backupLog` entries
* Remove 2nd remove call for `backupLog`
* Fix overwrite of backupLog during verify and not Restoring
* Log a start message inside backupLog as well
* Redirect tar's verify stderr to the log as well
* The status page in the webui now always loads the whole log with auto scroll.

### Notes
Although its deprecated, it seems that `$usbDestination` should be `$backupOptions['usbDestination']` (line 136) and `$txt .=` seems uninitialized at line 139.